### PR TITLE
fix: Requires Type format to match others

### DIFF
--- a/oracles/derelict/exterior.json
+++ b/oracles/derelict/exterior.json
@@ -43,7 +43,7 @@
       "Oracles": ["Stellar Object"],
       "Requires": {
         "Location": ["Deep Space"],
-        "Derelict Type": ["Settlement"]
+        "Derelict Type": "Settlement"
       }
     },
     {


### PR DESCRIPTION
Changes the "Derelict Type" on space stellar objects to match all the others in the file.