### PR TITLE
meta: adds json schemas

### DIFF
--- a/schema/AssetsSchema.json
+++ b/schema/AssetsSchema.json
@@ -1,0 +1,234 @@
+{
+  "definitions": {
+    "Ability": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "Text": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Enabled": {
+          "type": "boolean"
+        },
+        "Fields": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "Alter Properties": {
+          "$ref": "#/definitions/AlterProperties"
+        }
+      },
+      "required": [
+        "Text",
+        "Enabled",
+        "Fields",
+        "Alter Properties"
+      ]
+    },
+    "AlterProperties": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "Track": {
+          "$ref": "#/definitions/Track"
+        }
+      },
+      "required": [
+        "Track"
+      ]
+    },
+    "Asset": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "Name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Category": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Abilities": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Ability"
+          }
+        },
+        "Description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Fields": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "Track": {
+          "$ref": "#/definitions/Track"
+        },
+        "Counter": {
+          "$ref": "#/definitions/Counter"
+        }
+      },
+      "required": [
+        "Name",
+        "Category",
+        "Abilities",
+        "Description",
+        "Fields",
+        "Track",
+        "Counter"
+      ]
+    },
+    "Counter": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "Name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Starts At": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "Name",
+        "Starts At"
+      ]
+    },
+    "Source": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "Name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Page": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "Name",
+        "Page",
+        "Version"
+      ]
+    },
+    "Track": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "Name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Value": {
+          "type": "integer"
+        },
+        "Starts At": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "Name",
+        "Value",
+        "Starts At"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "Name": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "Tags": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "Source": {
+      "$ref": "#/definitions/Source"
+    },
+    "Assets": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/Asset"
+      }
+    }
+  },
+  "required": [
+    "Name",
+    "Tags",
+    "Source",
+    "Assets"
+  ]
+}

--- a/schema/GlossarySchema.json
+++ b/schema/GlossarySchema.json
@@ -1,0 +1,99 @@
+{
+  "definitions": {
+    "GlossaryTerm": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "Name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Color": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "Name",
+        "Color",
+        "Description"
+      ]
+    },
+    "Source": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "Name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Page": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "Name",
+        "Page",
+        "Version"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "Name": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "Category": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "Source": {
+      "$ref": "#/definitions/Source"
+    },
+    "Terms": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/GlossaryTerm"
+      }
+    }
+  },
+  "required": [
+    "Name",
+    "Category",
+    "Source",
+    "Terms"
+  ]
+}

--- a/schema/MovesSchema.json
+++ b/schema/MovesSchema.json
@@ -1,0 +1,109 @@
+{
+  "definitions": {
+    "Move": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "Category": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Progress Move": {
+          "type": "boolean"
+        },
+        "Text": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "Category",
+        "Name",
+        "Progress Move",
+        "Text"
+      ]
+    },
+    "Source": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "Name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Page": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "Name",
+        "Page",
+        "Version"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "Moves": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/Move"
+      }
+    },
+    "Name": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "Source": {
+      "$ref": "#/definitions/Source"
+    },
+    "Tags": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    }
+  },
+  "required": [
+    "Moves",
+    "Name",
+    "Source",
+    "Tags"
+  ]
+}

--- a/schema/OraclesSchema.json
+++ b/schema/OraclesSchema.json
@@ -1,0 +1,548 @@
+{
+  "definitions": {
+    "Inherit": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "From": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Oracles": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "Requires": {
+          "$ref": "#/definitions/Requires"
+        }
+      },
+      "required": [
+        "From",
+        "Oracles",
+        "Requires"
+      ]
+    },
+    "Oracle": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "Aliases": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "Character": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Initial": {
+          "type": "boolean"
+        },
+        "Ironsworn PlaceHolder": {
+          "type": "boolean"
+        },
+        "Max rolls": {
+          "type": "integer"
+        },
+        "Min rolls": {
+          "type": "integer"
+        },
+        "Name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Requires": {
+          "$ref": "#/definitions/Requires"
+        },
+        "Source": {
+          "$ref": "#/definitions/Source"
+        },
+        "Table": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Table"
+          }
+        },
+        "Tables": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Tables"
+          }
+        },
+        "Tags": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "required": [
+        "Aliases",
+        "Character",
+        "Description",
+        "Initial",
+        "Ironsworn PlaceHolder",
+        "Max rolls",
+        "Min rolls",
+        "Name",
+        "Requires",
+        "Source",
+        "Table",
+        "Tables",
+        "Tags"
+      ]
+    },
+    "Requires": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "Derelict Type": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "Environment": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "Location": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "Planetary Class": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "Region": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "Scale": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "Starship Type": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "Theme Type": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "Type": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "Zone": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "required": [
+        "Derelict Type",
+        "Environment",
+        "Location",
+        "Planetary Class",
+        "Region",
+        "Scale",
+        "Starship Type",
+        "Theme Type",
+        "Type",
+        "Zone"
+      ]
+    },
+    "Source": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "Name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Page": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "Name",
+        "Page",
+        "Version"
+      ]
+    },
+    "Table": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "Chance": {
+          "type": "integer"
+        },
+        "Table": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Table"
+          }
+        },
+        "Description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Details": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Quest Starter": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Thumbnail": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "Chance",
+        "Table",
+        "Description",
+        "Details",
+        "Quest Starter",
+        "Thumbnail"
+      ]
+    },
+    "Tables": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "Chance": {
+          "type": "integer"
+        },
+        "Description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "Initial": {
+          "type": "boolean"
+        },
+        "Requires": {
+          "$ref": "#/definitions/Requires"
+        },
+        "Table": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Table"
+          }
+        },
+        "Tags": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "Thumbnail": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "Chance",
+        "Description",
+        "Initial",
+        "Requires",
+        "Table",
+        "Tags",
+        "Thumbnail"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "Aliases": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "Category": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "Children": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "Description": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "Inherits": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/Inherit"
+      }
+    },
+    "Name": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "Oracles": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/Oracle"
+      }
+    },
+    "Parent": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "Requires": {
+      "$ref": "#/definitions/Requires"
+    },
+    "Sample Names": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "Source": {
+      "$ref": "#/definitions/Source"
+    },
+    "Tags": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "Thumbnail": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "Type": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "Aliases",
+    "Category",
+    "Children",
+    "Description",
+    "Inherits",
+    "Name",
+    "Oracles",
+    "Parent",
+    "Requires",
+    "Sample Names",
+    "Source",
+    "Tags",
+    "Thumbnail",
+    "Type"
+  ]
+}


### PR DESCRIPTION
This is to help with deserialization, and class generation.

This was generated by the current Datasworn json data in TheOracle, so the schemas should validate all the json files, but I didn't check.