### PR TITLE
re-highlight single 'weak hit' in moves

### DIFF
--- a/_data-master/moves.yaml
+++ b/_data-master/moves.yaml
@@ -1,7 +1,7 @@
 Name: Moves
 Source:
   Name: Starforged Backer Preview
-  Date: "113021"
+  Date: "112921"
 Moves:
   - Name: Begin a Session
     Category: Session Moves
@@ -101,7 +101,7 @@ Moves:
 
       On a **strong hit**, you are successful. Take +1 momentum.
 
-      On a weak hit, you succeed, but not without a cost. Make a suffer move (-1).
+      On a **weak hit**, you succeed, but not without a cost. Make a suffer move (-1).
 
       On a **miss**, you fail, or a momentary success is undermined by a dire turn of events. [Pay the Price](#Pay-the-Price).
   - Name: Secure an Advantage

--- a/moves.json
+++ b/moves.json
@@ -1,6 +1,6 @@
 {
   "Name": "Moves",
-  "Source": { "Name": "Starforged Backer Preview", "Date": "113021" },
+  "Source": { "Name": "Starforged Backer Preview", "Date": "112921" },
   "Moves": [
     {
       "Name": "Begin a Session",
@@ -79,7 +79,7 @@
           "Stat Options": { "Stats": ["Wits"] }
         }
       ],
-      "Text": "**When you attempt something risky or react to an imminent threat**, envision your action and roll. If you act...\n\n  * With speed, mobility, or agility: Roll +edge\n  * With resolve, command, or sociability: Roll +heart\n  * With strength, endurance, or aggression: Roll +iron\n  * With deception, stealth, or trickery: Roll +shadow\n  * With expertise, focus, or observation: Roll +wits\n\nOn a **strong hit**, you are successful. Take +1 momentum.\n\nOn a weak hit, you succeed, but not without a cost. Make a suffer move (-1).\n\nOn a **miss**, you fail, or a momentary success is undermined by a dire turn of events. [Pay the Price](#Pay-the-Price)."
+      "Text": "**When you attempt something risky or react to an imminent threat**, envision your action and roll. If you act...\n\n  * With speed, mobility, or agility: Roll +edge\n  * With resolve, command, or sociability: Roll +heart\n  * With strength, endurance, or aggression: Roll +iron\n  * With deception, stealth, or trickery: Roll +shadow\n  * With expertise, focus, or observation: Roll +wits\n\nOn a **strong hit**, you are successful. Take +1 momentum.\n\nOn a **weak hit**, you succeed, but not without a cost. Make a suffer move (-1).\n\nOn a **miss**, you fail, or a momentary success is undermined by a dire turn of events. [Pay the Price](#Pay-the-Price)."
     },
     {
       "Name": "Secure an Advantage",

--- a/roll20/moves.json
+++ b/roll20/moves.json
@@ -1,6 +1,6 @@
 {
   "Name": "Moves",
-  "Source": { "Name": "Starforged Backer Preview", "Date": "113021" },
+  "Source": { "Name": "Starforged Backer Preview", "Date": "112921" },
   "Moves": [
     {
       "Name": "Begin a Session",
@@ -84,7 +84,7 @@
           "Stat Options": { "Stats": ["Wits"] }
         }
       ],
-      "Text": "<p><strong>When you attempt something risky or react to an imminent threat</strong>, envision your action and roll. If you act…</p><ul><li>With speed, mobility, or agility: Roll +edge</li><li>With resolve, command, or sociability: Roll +heart</li><li>With strength, endurance, or aggression: Roll +iron</li><li>With deception, stealth, or trickery: Roll +shadow</li><li>With expertise, focus, or observation: Roll +wits</li></ul><p>On a <strong>strong hit</strong>, you are successful. Take +1 momentum.</p><p>On a weak hit, you succeed, but not without a cost. Make a suffer move (-1).</p><p>On a <strong>miss</strong>, you fail, or a momentary success is undermined by a dire turn of events. <u>Pay the Price</u>.</p>",
+      "Text": "<p><strong>When you attempt something risky or react to an imminent threat</strong>, envision your action and roll. If you act…</p><ul><li>With speed, mobility, or agility: Roll +edge</li><li>With resolve, command, or sociability: Roll +heart</li><li>With strength, endurance, or aggression: Roll +iron</li><li>With deception, stealth, or trickery: Roll +shadow</li><li>With expertise, focus, or observation: Roll +wits</li></ul><p>On a <strong>strong hit</strong>, you are successful. Take +1 momentum.</p><p>On a <strong>weak hit</strong>, you succeed, but not without a cost. Make a suffer move (-1).</p><p>On a <strong>miss</strong>, you fail, or a momentary success is undermined by a dire turn of events. <u>Pay the Price</u>.</p>",
       "id": "move-face-danger"
     },
     {


### PR DESCRIPTION
Minor typo, '**' removed from one 'weak hit'.
I also changed the source to 1129 rather than 1130 as previously advertised.